### PR TITLE
Apple Silicon Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,5 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+.DS_Store

--- a/InfiniteYouSampler.py
+++ b/InfiniteYouSampler.py
@@ -32,6 +32,7 @@ class InfiniteYouSampler:
                 "id_image": ("IMAGE",),
                 "base_model": (['auto'] + folder_paths.get_filename_list("diffusion_models"),),
                 "seed": ("INT", {
+                    "default": 42
                 }),
                 "prompt": ("STRING", {
                     "multiline": True,
@@ -79,6 +80,12 @@ class InfiniteYouSampler:
                     "default": 'aes_stage2'
                 }),
                 "control_image": ("IMAGE",),
+                "enable_realism": ("BOOLEAN", {
+                    "default": False
+                }),
+                "enable_anti_blur": ("BOOLEAN", {
+                    "default": False
+                }),
             },
         }
 
@@ -100,6 +107,8 @@ class InfiniteYouSampler:
         infusenet_guidance_end=1.0,
         model_version='aes_stage2',
         control_image=None,
+        enable_realism=False,
+        enable_anti_blur=False,
     ):
         device = comfy.model_management.get_torch_device()
         if device.type == 'cuda':
@@ -126,6 +135,15 @@ class InfiniteYouSampler:
             infu_flux_version=infu_flux_version,
             model_version=model_version,
         )
+
+        # Load LoRAs if enabled
+        loras = []
+        if enable_realism:
+            loras.append([os.path.join(model_dir, 'supports/optional_loras/flux_realism_lora.safetensors'), 'realism', 1.0])
+        if enable_anti_blur:
+            loras.append([os.path.join(model_dir, 'supports/optional_loras/flux_anti_blur_lora.safetensors'), 'anti_blur', 1.0])
+        if loras:
+            pipe.load_loras(loras)
 
         control_image_pil = None
         if control_image is not None:

--- a/InfiniteYouSampler.py
+++ b/InfiniteYouSampler.py
@@ -13,7 +13,7 @@ repo_dir = os.path.join(this_path,"InfiniteYou")
 requirements_txt = os.path.join(repo_dir,"requirements.txt")
 
 if not os.path.exists(requirements_txt):
-    pygit2.clone_repository("https://github.com/bytedance/InfiniteYou", repo_dir, depth=1)
+    pygit2.clone_repository("https://github.com/azmenak/InfiniteYou", repo_dir, depth=1)
     if not os.path.exists(requirements_txt):
         print("*** Could not get InfiniteYou repository.  Please install git.")
 

--- a/InfiniteYouSampler.py
+++ b/InfiniteYouSampler.py
@@ -101,7 +101,9 @@ class InfiniteYouSampler:
         model_version='aes_stage2',
         control_image=None,
     ):
-        torch.cuda.set_device(comfy.model_management.get_torch_device())
+        device = comfy.model_management.get_torch_device()
+        if device.type == 'cuda':
+            torch.cuda.set_device(device)
 
         infu_flux_version = 'v1.0'
         model_dir = 'ByteDance/InfiniteYou'

--- a/InfiniteYouSampler.py
+++ b/InfiniteYouSampler.py
@@ -113,6 +113,8 @@ class InfiniteYouSampler:
         device = comfy.model_management.get_torch_device()
         if device.type == 'cuda':
             torch.cuda.set_device(device)
+        elif device.type == 'mps':
+            torch.set_default_device("mps:0")
 
         infu_flux_version = 'v1.0'
         model_dir = 'ByteDance/InfiniteYou'
@@ -137,11 +139,14 @@ class InfiniteYouSampler:
         )
 
         # Load LoRAs if enabled
+        lora_dir = os.path.join(model_dir, 'supports', 'optional_loras')
+        if not os.path.exists(lora_dir): 
+            lora_dir = "./models/InfiniteYou/supports/optional_loras"
         loras = []
         if enable_realism:
-            loras.append([os.path.join(model_dir, 'supports/optional_loras/flux_realism_lora.safetensors'), 'realism', 1.0])
+            loras.append([os.path.join(lora_dir, 'flux_realism_lora.safetensors'), 'realism', 1.0])
         if enable_anti_blur:
-            loras.append([os.path.join(model_dir, 'supports/optional_loras/flux_anti_blur_lora.safetensors'), 'anti_blur', 1.0])
+            loras.append([os.path.join(lora_dir, 'flux_anti_blur_lora.safetensors'), 'anti_blur', 1.0])
         if loras:
             pipe.load_loras(loras)
 


### PR DESCRIPTION
Fix to avoid loading CUDA device and updates the InfiniteYou repo to one compatible with Apple Silicon

Manage to get this running on my local machine (M4 Max 128BG)

Takes ~500s to run with:
- 1024x1024 input image
- steps: `30`
- guidance: `3.5`
- conditioning scale: `1`
- guidance start: `0`
- guidance end: `1`
- model version: `aes_stage2`